### PR TITLE
Add try catch for folder permissions

### DIFF
--- a/src/projects.ts
+++ b/src/projects.ts
@@ -175,7 +175,12 @@ export default class Projects {
                 let ignoredFolders = this.config.get('ignoredFolders', []);
                 projectDirs.forEach(proDir => {
                     let pros = fs.readdirSync(proDir).filter(dir => {
-                        return !dir.startsWith('.') && ignoredFolders.indexOf(dir) === -1 && fs.statSync(path.join(proDir, dir)).isDirectory();
+                        if (dir.startsWith('.') || ignoredFolders.indexOf(dir) !== -1) return false;
+                        try {
+                            return fs.statSync(path.join(proDir, dir)).isDirectory();
+                        } catch (e) {
+                            return false;
+                        }
                     }).map(dir => {
                         return {
                             label: dir,


### PR DESCRIPTION
This fixes an issue that gave an error when you didn't have read permission on a folder. 